### PR TITLE
Fixed lock animation and crop rect initializing (Android)

### DIFF
--- a/android/src/main/kotlin/com/dns_technologies/mlkit_scanner/CameraViewScannerCamera.kt
+++ b/android/src/main/kotlin/com/dns_technologies/mlkit_scanner/CameraViewScannerCamera.kt
@@ -102,8 +102,8 @@ class CameraViewScannerCamera(
 
     override fun onCameraOpened(options: CameraOptions) {
         cameraOptions = options
-        onInitSuccess.invoke()
         cameraView.useCenterFocus(focusCenter)
+        onInitSuccess.invoke()
         cameraView.removeCameraListener(this)
         super.onCameraOpened(options)
     }

--- a/android/src/main/kotlin/com/dns_technologies/mlkit_scanner/CenterFocusView.kt
+++ b/android/src/main/kotlin/com/dns_technologies/mlkit_scanner/CenterFocusView.kt
@@ -25,6 +25,8 @@ class CenterFocusView constructor(
         duration = 300
         fillAfter = true
     }
+    private val autofocusLockedFinalPosition: Pair<Float, Float>
+        get() = Pair(lock.width * 0.8F - lock.x, lock.height * 0.8F - lock.y)
     val cameraListener: CameraListener
 
     init {
@@ -123,8 +125,7 @@ class CenterFocusView constructor(
     }
 
     private fun lockMovementAnimation(): Animation {
-        val deltaX = lock.width * 0.8F - lock.x
-        val deltaY = lock.height * 0.8F - lock.y
+        val (deltaX, deltaY) = autofocusLockedFinalPosition
         return TranslateAnimation(center.first, deltaX, center.second, deltaY).apply {
             startOffset = 300
             duration = 500
@@ -165,8 +166,9 @@ class CenterFocusView constructor(
             return
         }
         if (lock.visibility == View.VISIBLE) {
+            val (deltaX, deltaY) = autofocusLockedFinalPosition
             lock.apply {
-                val translateAnimation = lockMovementAnimation().apply {
+                val translateAnimation = TranslateAnimation(deltaX, deltaX, deltaY, deltaY).apply {
                     startOffset = 0
                     duration = 0
                     fillAfter = true


### PR DESCRIPTION
Fixed lock animation when changing layout
When initializing the crop rect, the focus is now set correctly